### PR TITLE
feat: support 'main' branch

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 <h1>deploy-gh</h1>
-<p>This page was deployed by deploy-gh</p>
+<p>This page was deployed by <a href="https://github.com/nfischer/deploy-gh">nfischer/deploy-gh</a></p>
 </body>
 </html>
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 var shell = require('shelljs');
 
-if (process.argv[2] === '--silent')
+if (process.argv[2] === '--silent') {
   shell.config.silent = true;
+}
+
+var dryRun = false;
+if (process.argv[2] === '--dryrun') {
+  dryRun = true;
+}
 
 shell.exec('git checkout gh-pages');
 if (shell.error()) {
@@ -13,10 +19,29 @@ if (shell.error()) {
   }
 }
 
-shell.exec('git rev-parse --abbrev-ref HEAD');
-shell.exec('git merge master --commit');
-shell.exec('git push origin gh-pages');
-shell.exec('git checkout -');
+function findMainBranch() {
+  var gitMainBranches = [ 'main', 'master' ];
+  for (branch of gitMainBranches) {
+    var branchExists = shell.exec('git branch --list ' + branch, { silent: true }).trim() != '';
+    if (branchExists) {
+      return branch;
+    }
+  }
+  throw new Error('Cannot determine main branch of repo');
+}
+
+var mainBranch = findMainBranch();
+console.log('Merging ' + mainBranch + ' branch into gh-pages branch');
+shell.exec('git merge ' + findMainBranch() + ' --commit');
+
+if (dryRun) {
+  console.warn('This is a dryrun, so this is not pushing to origin!');
+} else {
+  console.log('Deploying to gh-pages branch...');
+  shell.exec('git push origin gh-pages', { fatal: true });
+  console.log('Your change was successfully pushed!');
+}
+shell.exec('git checkout -', { fatal: true });
 
 // Figure out the user and project name for this repo.
 var url = shell.exec('git remote show -n origin', {silent: true})
@@ -29,14 +54,26 @@ if (url.match(/^https/)) {
 } else if (url.match(/^git/)) {
   repoInfo = url.match(/git@github.com:([^/]+)\/([^.]+)\..*/);
 } else {
-  console.warn('Unknown origin pattern: "' + url + '"');
+  console.warn('Unknown origin pattern: ' + JSON.stringify(url));
   shell.exit(0);
 }
 
+var ghPagesUrl = '[Unable to figure out GitHub pages URL]';
 if (repoInfo) {
   var user = repoInfo[1];
   var project = repoInfo[2];
-  shell.echo(['Deployed to https://', user, '.github.io/', project, '/'].join(''));
+  ghPagesUrl = 'https://' + user + '.github.io/' + project + '/';
+}
+
+if (dryRun) {
+  console.log('Would have deployed to ' + ghPagesUrl + ' (but this is a dryrun)');
 } else {
-  console.warn('Unable to figure out repo name: ');
+  console.log('Deployed to ' + ghPagesUrl);
+}
+
+if (dryRun) {
+  console.log('\nEven though this is a dryrun, this probably modified your ' +
+              'local git branches (but should not have pushed those ' +
+              'changes). Please verify the local branch changes and step ' +
+              'back if necessary.');
 }


### PR DESCRIPTION
We previously hardcoded 'master' as the primary branch name. This adds
support (and preference) for the name 'main', with a fallback to
'master'.

This also adds a --dryrun switch for easier manual testing.

Lastly, this includes a minimal HTML edit just to make sure the deploy
actually works.